### PR TITLE
Remove out-of-spec TTL behavior tests (PSR-16)

### DIFF
--- a/src/SimpleCacheTest.php
+++ b/src/SimpleCacheTest.php
@@ -72,25 +72,6 @@ abstract class SimpleCacheTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @return array
-     */
-    public static function invalidTtl()
-    {
-        return [
-            [''],
-            [true],
-            [false],
-            ['abc'],
-            [2.5],
-            [' 1'], // can be casted to a int
-            ['12foo'], // can be casted to a int
-            ['025'], // can be interpreted as hex
-            [new \stdClass()],
-            [['array']],
-        ];
-    }
-
-    /**
      * Data provider for valid keys.
      *
      * @return array
@@ -503,32 +484,6 @@ abstract class SimpleCacheTest extends \PHPUnit_Framework_TestCase
         }
 
         $this->cache->deleteMultiple('key');
-    }
-
-    /**
-     * @expectedException \Psr\SimpleCache\InvalidArgumentException
-     * @dataProvider invalidTtl
-     */
-    public function testSetInvalidTtl($ttl)
-    {
-        if (isset($this->skippedTests[__FUNCTION__])) {
-            $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
-        }
-
-        $this->cache->set('key', 'value', $ttl);
-    }
-
-    /**
-     * @expectedException \Psr\SimpleCache\InvalidArgumentException
-     * @dataProvider invalidTtl
-     */
-    public function testSetMultipleInvalidTtl($ttl)
-    {
-        if (isset($this->skippedTests[__FUNCTION__])) {
-            $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
-        }
-
-        $this->cache->setMultiple(['key' => 'value'], $ttl);
     }
 
     public function testNullOverwrite()


### PR DESCRIPTION
Handling invalid TTLs is not defined in current spec, and
what the exact implementation will be is still very much
up in the air.

See https://github.com/php-cache/integration-tests/issues/75